### PR TITLE
Completely overhaul CMakeLists.txt

### DIFF
--- a/indigo/CMakeLists.txt
+++ b/indigo/CMakeLists.txt
@@ -1,17 +1,35 @@
+cmake_minimum_required(VERSION 2.8)
 
-get_cmake_property(_variableNames VARIABLES)
-foreach (_variableName ${_variableNames})
-  message(STATUS "${_variableName}=${${_variableName}}")
-endforeach()
+# Make sure libtool doesn't set RPATHs
+# I REALLY wish there was a better way to do this...
+execute_process(COMMAND bash -c "awk '/^include / { system(sprintf(\"cd /etc; cat %s 2>/dev/null\", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | sed -e 's/#.*//;/^[   ]*hwcap[        ]/d;s/[:,      ]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/\"//g;/^$/d' | tr '\n' ' '" OUTPUT_VARIABLE ld_so_conf_paths)
+execute_process(COMMAND bash -c "echo $LD_LIBRARY_PATH | sed 's/:/ /g' | tr '\n' ' '" OUTPUT_VARIABLE ld_library_paths)
+set(lt_cv_sys_lib_dlsearch_path_spec "/lib64 /usr/lib64 /lib /usr/lib ${ld_so_conf_paths}${ld_library_paths}${CMAKE_INSTALL_PREFIX}/lib")
 
-add_custom_target(compile_openrtm_aist ALL
-  COMMAND ./build/autogen
-  COMMAND ./configure --prefix=${CMAKE_INSTALL_PREFIX}
-  COMMAND make
-  COMMAND env
-  COMMAND make install DESTDIR=$ENV{PWD}/debian/ros-indigo-openrtm-aist
+# This target is straightforward: Use ./build/autogen to produce ./configure
+add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/configure
+  COMMAND ${PROJECT_SOURCE_DIR}/build/autogen
+  DEPENDS ${PROJECT_SOURCE_DIR}/build/autogen
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+# Again, straightforward: Use ./configure to produce ./Makefile
+add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/Makefile
+  COMMAND ${PROJECT_SOURCE_DIR}/configure --prefix=${CMAKE_INSTALL_PREFIX}
+  DEPENDS ${PROJECT_SOURCE_DIR}/configure
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+
+# Now we can invoke make, but only if the Makefile is present
+add_custom_target(compile_openrtm_aist ALL
+  DEPENDS ${PROJECT_SOURCE_DIR}/Makefile
+  COMMAND export lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR})
+
+# Install target depends on make target, but doesn't have ALL
+add_custom_target(install_openrtm_aist
+  DEPENDS compile_openrtm_aist
+  COMMAND export lt_cv_sys_lib_dlsearch_path_spec=${lt_cv_sys_lib_dlsearch_path_spec} && \$\(MAKE\) -C ${PROJECT_SOURCE_DIR} install)
+
+# This install CODE will trigger the target install_openrtm_aist
+install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" --build \"${CMAKE_BINARY_DIR}\" --target install_openrtm_aist)")
 install(FILES package.xml DESTINATION share/openrtm_aist/)
 foreach(target rtm-config rtm-naming rtm-skelwrapper rtc-template coil-config rtcd rtcprof)
   install(CODE "execute_process(COMMAND cmake -E create_symlink ../../bin/${target} ${target} WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/share/openrtm_aist)")


### PR DESCRIPTION
The current `CMakeLists.txt` for this project has two major problems:
1. It ONLY works for debian generation, and only under certain conditions (the ones on the buildfarm). That means it won't work to build this package from source, or on any other system besides the buildfarm.
2. `libtool` is setting static rpaths on all of the executables and libraries. rpaths are not allowed in RPM packages, and they are not necessary in this context as ROS is setting the `LD_LIBRARY_PATH` appropriately.

There are also some minor issues:
1. "make" properties don't get passed to the generated makefile. This is a result of invoking `make` directly instead of invoking it as `$(MAKE)`. The latter will pass any variables in the make environment (such as `CFLAGS`), and will ensure that parallelization happens. Currently, even on a 16 core machine, the code is compiled with `-j 1`, which is very slow. Using `$(MAKE)` also ensures that the native make utility is called, which is sometimes `gmake` and not `make`.
2. The code is unnecessarily re-compiled during the install phase. This, compounded with the parallelization issue, means that builds for this package are taking 2-3 times longer than is necessary.

This PR will fix all four of these problems, allowing faster, more correct builds on ANY system (debian buildfarm included), and will prevent libtool from detecting a need for static rpaths.

Example build break on Fedora: https://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-openrtm-aist_binaryrpm_heisenbug_x86_64/12/console

Thanks,

--scott
