### PR TITLE
add  a "-Wbuse_quotes" option to openrtm-aist.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1091,7 +1091,7 @@ if test "x$have_omniorb" = "xyes" ; then
 	PATH_NORM($omniidl)
 	omniidl=$n_path
 	IDLC=$omniidl
-	IDL_FLAGS="-bcxx -Wba -nf"
+	IDL_FLAGS="-bcxx -Wba -nf -Wbuse_quotes"
 
 	dnl omniNames
 	PATH_NORM($omniNames)


### PR DESCRIPTION
``#include <xxx>`` を ``#include "xxx"``に変更してしまうのを防ぎたいですが，問題ありますでしょうか？

related issue : https://github.com/start-jsk/rtmros_common/issues/861


http://omniorb.sourceforge.net/omni40/omniORB/omniORB005.html