### PR TITLE
[WIP] Add patch for OpenRTM-aist 1.1.2

### DIFF
--- a/src/lib/rtm/OutPort.h
+++ b/src/lib/rtm/OutPort.h
@@ -13,7 +13,7 @@
  *         Advanced Industrial Science and Technology (AIST), Japan
  *     All rights reserved.
  *
- * $Id: OutPort.h 2723 2016-05-24 02:13:45Z kawauchi $
+ * $Id: OutPort.h 2755 2016-06-11 07:31:16Z n-ando $
  *
  */
 
@@ -138,8 +138,12 @@ namespace RTC
 #endif
         m_value(value), m_onWrite(0), m_onWriteConvert(0)
     {
-      addProperty("dataport.data_value", m_value);
-      m_propValueIndex = NVUtil::find_index(m_profile.properties, "dataport.data_value");
+      addProperty("dataport.data_value", CORBA::Short(0));
+      {
+	Guard guard(m_profile_mutex);
+	m_propValueIndex = NVUtil::find_index(m_profile.properties,
+					      "dataport.data_value");
+      }
     }
     
     /*!
@@ -211,7 +215,10 @@ namespace RTC
           (*m_onWrite)(value);
           RTC_TRACE(("OnWrite called"));
         }
-      m_profile.properties[m_propValueIndex].value <<= value;
+      {
+	Guard guard(m_profile_mutex);
+	m_profile.properties[m_propValueIndex].value <<= value;
+      }
 
       bool result(true);
       std::vector<const char *> disconnect_ids;


### PR DESCRIPTION
I don't know setting of this PR is correct.

I faced an issue in running a rtmros robot on melodic: https://github.com/start-jsk/rtmros_hironx/issues/538
While I was debugging, I found the information which says that OpenRTM-aist 1.1.2 (which is released on melodic) has a bug: https://choreonoid.org/ja/manuals/latest/openrtm/install.html#openrtmplugin-patch-for-version112
After I tried a patch distributed on that website, the issue seems disappeared.

This PR applies that patch to `release/melodic/openrtm_aist` branch.